### PR TITLE
Fix testing w/o galixy prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
 install:
   # Add ansible.cfg to pick up roles path.
   - echo -e '[defaults]\nroles_path = ../' > ansible.cfg
+  # Galaxy would normally install this with a cevich prefix
+  - ROLEBASE=$(basename $PWD) cd .. && ln -s $ROLEBASE cevich.$ROLEBASE
 
 script:
   - for i in $TYPOS; do echo; echo "$i"; git log -p $TRAVIS_COMMIT_RANGE | grep -a -2 "$i"; test "$?" != "0" || exit 1; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,16 @@ install:
   # Add ansible.cfg to pick up roles path.
   - echo -e '[defaults]\nroles_path = ../' > ansible.cfg
   # Galaxy would normally install this with a cevich prefix
-  - ROLEBASE=$(basename $PWD) cd .. && ln -s $ROLEBASE cevich.$ROLEBASE
+  - export ROLEBASE="$(basename $PWD)" && ln -sfv "$ROLEBASE" "../cevich.$ROLEBASE"
 
 script:
-  - for i in $TYPOS; do echo; echo "$i"; git log -p $TRAVIS_COMMIT_RANGE | grep -a -2 "$i"; test "$?" != "0" || exit 1; done
+  - >
+        echo "$(git log -1 --format=%H origin/master)" > /tmp/start;
+        echo "$(git log -1 --format=%H HEAD)" > /tmp/end;
+        git log -p $(cat /tmp/start)..$(cat /tmp/end) -- . ':!.travis.yml' &> /tmp/commits;
+        echo "Typos found:";
+        egrep -a -i -2 "$TYPOS" /tmp/commits | tee /tmp/typos;
+        test "$(cat /tmp/typos | wc -l)" -eq "0" || exit 1;
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
   - ansible-playbook -i tests/inventory tests/test.yml
   - >

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ License
 -------
 
     parallel_git_repos makes it simple to clone from multiple git repositories in parallel.
-    Copyright (C) 2017  Christopher. C Evich
+    Copyright (C) 2017  Christopher C. Evich
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,4 +10,4 @@
        - repo: "https://github.com/ansible/ansible-container"
          dest: "{{ playbook_dir }}/path/to/dir/container"
   roles:
-     - parallel_git_repos
+     - cevich.parallel_git_repos


### PR DESCRIPTION
When 'ansible-galaxy install ...' runs, it sticks a username prefix
infront of roles.  However, travis testing does not reflect this.  Fix
it by using the proper, galaxy name from the test playbook and dropping
a symlink for the repo. clone directory basename.

Signed-off-by: Chris Evich <cevich@redhat.com>